### PR TITLE
Printing fixes

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -23,11 +23,11 @@ function print_header(ws::COSMO.Workspace)
 	nothing
 end
 
-function print_iteration(settings::COSMO.Settings, iter::Int64, cost::Float64, r_prim::Float64, r_dual::Float64)
-
+function print_iteration(ws::COSMO.Workspace, iter::Int64, cost::Float64, r_prim::Float64, r_dual::Float64)
+	settings = ws.settings
 	if mod(iter, 1) == 0 || iter == 1 || iter == 2 || iter == settings.max_iter
 		if mod(iter, settings.check_termination) == 0
-			@printf("%d\t%.4e\t%.4e\t%.4e\t%.4e\n", iter, cost, r_prim, r_dual, settings.rho)
+			@printf("%d\t%.4e\t%.4e\t%.4e\t%.4e\n", iter, cost, r_prim, r_dual, ws.ρ)
 		else
 			@printf("%d\t%.4e\t ---\t\t\t---\n", iter, cost)
 		end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -58,6 +58,7 @@ function optimize!(ws::COSMO.Workspace)
 	ws.sm = (settings.scaling > 0) ? ScaleMatrices(ws.p.model_size[1], ws.p.model_size[2]) : ScaleMatrices()
 
 	# perform preprocessing steps (scaling, initial KKT factorization)
+	ws.times.factor_time = 0
 	ws.times.setup_time = @elapsed setup!(ws);
 	ws.times.proj_time  = 0. #reset projection time
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -119,7 +119,7 @@ function optimize!(ws::COSMO.Workspace)
 			end
 
 			# print iteration steps
-			settings.verbose && print_iteration(settings, iter, cost, r_prim, r_dual)
+			settings.verbose && print_iteration(ws, iter, cost, r_prim, r_dual)
 
 			if has_converged(ws, r_prim, r_dual)
 				status = :Solved

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,7 +29,7 @@ mutable struct ResultTimes{T <: AbstractFloat}
 	post_time::T
 end
 
-ResultTimes{T}() where{T} = ResultTimes{T}(0., 0., 0., 0., 0., 0., 0.)
+ResultTimes{T}() where{T} = ResultTimes{T}(T(NaN), T(NaN), T(NaN), T(NaN), T(NaN), T(NaN), T(NaN))
 ResultTimes(T::Type = DefaultFloat) = ResultTimes{T}()
 
 function Base.show(io::IO, obj::ResultTimes)
@@ -96,7 +96,7 @@ end
 
 function Base.show(io::IO, obj::Result)
 	print(io,">>> COSMO - Results\nStatus: $(obj.status)\nIterations: $(obj.iter)\nOptimal Objective: $(round.(obj.obj_val, digits = 2))\nRuntime: $(round.(obj.times.solver_time * 1000, digits = 2))ms\nSetup Time: $(round.(obj.times.setup_time * 1000, digits = 2))ms\n")
-	obj.times.iter_time != NaN && print("Avg Iter Time: $(round.((obj.times.iter_time / obj.iter) * 1000, digits = 2))ms")
+	!isnan(obj.times.iter_time) && print("Avg Iter Time: $(round.((obj.times.iter_time / obj.iter) * 1000, digits = 2))ms")
 end
 
 struct Info{T <: AbstractFloat}

--- a/test/UnitTests/print.jl
+++ b/test/UnitTests/print.jl
@@ -1,6 +1,6 @@
 using COSMO, Test, Random
 
-settings = COSMO.Settings()
+ws = COSMO.Workspace()
 iter = 10
 cost = 20.
 r_prim = 1.5e-3
@@ -10,8 +10,8 @@ rt = 0.7
 
 
 @testset "Printing" begin
-   @test COSMO.print_iteration(settings, iter, cost, r_prim, r_dual) == nothing
-   @test COSMO.print_iteration(settings, settings.check_termination, cost, r_prim, r_dual) == nothing
-   @test COSMO.print_result(status, iter, cost, rt) == nothing
+   @test COSMO.print_iteration(ws, iter, cost, r_prim, r_dual) == nothing
+   @test COSMO.print_iteration(ws, settings.check_termination, cost, r_prim, r_dual) == nothing
+   @test COSMO.print_result(ws, iter, cost, rt) == nothing
 end
 nothing

--- a/test/UnitTests/print.jl
+++ b/test/UnitTests/print.jl
@@ -11,7 +11,7 @@ rt = 0.7
 
 @testset "Printing" begin
    @test COSMO.print_iteration(ws, iter, cost, r_prim, r_dual) == nothing
-   @test COSMO.print_iteration(ws, settings.check_termination, cost, r_prim, r_dual) == nothing
-   @test COSMO.print_result(ws, iter, cost, rt) == nothing
+   @test COSMO.print_iteration(ws, ws.settings.check_termination, cost, r_prim, r_dual) == nothing
+   @test COSMO.print_result(status, iter, cost, rt) == nothing
 end
 nothing


### PR DESCRIPTION
1. Correctly prints updated values of `rho`
2. Initialise timings with `NaN`s. This avoids showing non-calculated timings as zero, which might be misleading. Relevant when `settings.verbose_timing = false`.
3. Avoid printing average iteration time when `settings.verbose_timing = false`.

Edit: Tests run on my machine but fail on CI with
```
The command "julia -e 'if VERSION >= v"0.7.0-" using Pkg; end; Pkg.clone(pwd()); Pkg.build("COSMO"); Pkg.test("COSMO"; coverage=true)';" exited with 1.
```