### PR TITLE
Add basic iterative KKT solvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ matrix:
 
 ## uncomment the following lines to override the default test script
 script:
-   - julia -e 'if VERSION >= v"0.7.0-" using Pkg; end; Pkg.clone(pwd()); Pkg.build("COSMO"); Pkg.test("COSMO"; coverage=true)';
+  - julia --project --color=yes -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:
   # push coverage results to Codecov
-  - julia -e 'if VERSION >= v"0.7.0-" using Pkg; end; cd(Pkg.dir("COSMO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 
 jobs:
   include:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,110 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.1.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MathOptInterface]]
+deps = ["Compat", "Unicode"]
+git-tree-sha1 = "5d3de69c9220610d0336ab45d3eb8b6ac7a7c807"
+uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+version = "0.8.4"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[UnsafeArrays]]
+deps = ["Compat"]
+git-tree-sha1 = "460f4f7bab69dd47512ac8ec4b2c14b28c6cb4a0"
+uuid = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+version = "0.3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "COSMO"
+uuid = "c9640460-5c3f-11e9-2ef6-617bfcaaaa93"
+authors = ["Michael <michael@garstka.org>"]
+version = "0.4.1"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+
+[compat]
+julia = "^1"
+MathOptInterface = "0.8, 0.9"
+UnsafeArrays = "0.3, 0.4"

--- a/src/COSMO.jl
+++ b/src/COSMO.jl
@@ -14,6 +14,9 @@ include("./kktsolver.jl")
 if in("Pardiso",keys(Pkg.installed()))
     include("./kktsolver_pardiso.jl")
 end
+if in("IterativeSolvers", keys(Pkg.installed())) && in("LinearMaps", keys(Pkg.installed()))
+    include("./kktsolver_indirect.jl")
+end
 
 
 include("./algebra.jl")

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -1,4 +1,5 @@
 using  LinearAlgebra
+import LinearAlgebra: lmul!, rmul!
 const  IdentityMatrix = UniformScaling{Bool}
 
 

--- a/src/kktsolver_indirect.jl
+++ b/src/kktsolver_indirect.jl
@@ -1,0 +1,73 @@
+using LinearMaps, IterativeSolvers
+
+mutable struct CGKKTSolver{TP, TA, T} <: COSMO.AbstractKKTSolver
+    m::Integer
+    n::Integer
+    P::TP
+    A::TA
+    σ::T
+    ρ::Vector{T}
+    # Memory and statistics for cg
+    previous_cg_solution::Vector{T}
+    counter::Int
+    multiplications::Vector{Int}
+    tmp_n::Vector{T}
+    tmp_m::Vector{T}
+
+    function CGKKTSolver(P::TP, A::TA, σ::T, ρ) where {TP, TA, T}
+        m, n = size(A)
+        new{TP, TA, T}(m, n, P, A, σ, ρ,
+            zeros(T, n), 1, zeros(Int, 1), zeros(T, n), zeros(T, m))
+    end
+end
+
+function solve!(S::CGKKTSolver, y::AbstractVector{T}, x::AbstractVector{T}) where {T}
+    # Solves the (KKT) linear system
+    # | P + σI     A'  |  |y1|  =  |x1|
+    # | A        -I/ρ  |  |y2|  =  |x2|
+    # x1,y1: R^n, x2/y2: R^m
+    # where [y1; y2] := y, [x1; x2] := x 
+
+    # In particular we perform cg on the reduced system
+    # (P + σΙ + Α'ρΑ)y1 = x1 + A'ρx2
+    # And then recover y2 as
+    # y2 = ρ(Ay1 - x2)
+
+    x1 = view(x, 1:S.n); y1 = view(y, 1:S.n)
+    x2 = view(x, S.n+1:S.n+S.m); y2 = view(y, S.n+1:S.n+S.m)
+
+    # Form right-hand side for cg: y1 = x1 + A'ρx2
+    @. y2 = S.ρ*x2
+    mul!(y1, S.A', y2)
+    y1 .+= x1
+    function cg_mul!(y::AbstractVector{T}, x::AbstractVector{T}) where {T}
+        # y = (P + σΙ + Α'ρΑ)x
+        mul!(S.tmp_m, S.A, x)
+        @. S.tmp_m .*= S.ρ
+        mul!(S.tmp_n, S.A', S.tmp_m)
+        axpy!(S.σ, x, S.tmp_n)
+        mul!(y, S.P, x)
+        axpy!(one(T), S.tmp_n, y)
+        S.multiplications[end] += 1
+        return y
+    end
+    L = LinearMap(cg_mul!, S.n; ismutating=true, issymmetric=true)
+    tol = 1/S.counter^2
+    cg!(S.previous_cg_solution, L, y1, tol=tol/norm(y1), initially_zero=false) #, maxiter=10)
+    # @assert tol > norm(L*S.previous_cg_solution - y1)
+    copyto!(y1, S.previous_cg_solution)
+
+    # y2 = Ay1 - x2
+    mul!(y2, S.A, y1)
+    axpy!(-one(T), x2, y2)
+    @. y2 .*= S.ρ
+
+    S.counter += 1
+    push!(S.multiplications, 0)
+
+    return y
+end
+
+function update_rho!(S::CGKKTSolver, ρ)
+    S.ρ .= ρ
+end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -24,11 +24,11 @@ function print_header(ws::COSMO.Workspace)
 	nothing
 end
 
-function print_iteration(settings::COSMO.Settings, iter::Int64, cost::Float64, r_prim::Float64, r_dual::Float64)
-
+function print_iteration(ws::COSMO.Workspace, iter::Int64, cost::Float64, r_prim::Float64, r_dual::Float64)
+	settings = ws.settings
 	if mod(iter, 1) == 0 || iter == 1 || iter == 2 || iter == settings.max_iter
 		if mod(iter, settings.check_termination) == 0
-			@printf("%d\t%.4e\t%.4e\t%.4e\t%.4e\n", iter, cost, r_prim, r_dual, settings.rho)
+			@printf("%d\t%.4e\t%.4e\t%.4e\t%.4e\n", iter, cost, r_prim, r_dual, ws.ρ)
 		else
 			@printf("%d\t%.4e\t ---\t\t\t---\n", iter, cost)
 		end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -58,6 +58,7 @@ function optimize!(ws::COSMO.Workspace)
 	ws.sm = (settings.scaling > 0) ? ScaleMatrices(ws.p.model_size[1], ws.p.model_size[2]) : ScaleMatrices()
 
 	# perform preprocessing steps (scaling, initial KKT factorization)
+	ws.times.factor_time = 0
 	ws.times.setup_time = @elapsed setup!(ws);
 	ws.times.proj_time  = 0. #reset projection time
 
@@ -119,7 +120,7 @@ function optimize!(ws::COSMO.Workspace)
 			end
 
 			# print iteration steps
-			settings.verbose && print_iteration(settings, iter, cost, r_prim, r_dual)
+			settings.verbose && print_iteration(ws, iter, cost, r_prim, r_dual)
 
 			if has_converged(ws, r_prim, r_dual)
 				status = :Solved

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,7 +29,7 @@ mutable struct ResultTimes{T <: AbstractFloat}
 	post_time::T
 end
 
-ResultTimes{T}() where{T} = ResultTimes{T}(0., 0., 0., 0., 0., 0., 0.)
+ResultTimes{T}() where{T} = ResultTimes{T}(T(NaN), T(NaN), T(NaN), T(NaN), T(NaN), T(NaN), T(NaN))
 ResultTimes(T::Type = DefaultFloat) = ResultTimes{T}()
 
 function Base.show(io::IO, obj::ResultTimes)
@@ -96,7 +96,7 @@ end
 
 function Base.show(io::IO, obj::Result)
 	print(io,">>> COSMO - Results\nStatus: $(obj.status)\nIterations: $(obj.iter)\nOptimal Objective: $(round.(obj.obj_val, digits = 2))\nRuntime: $(round.(obj.times.solver_time * 1000, digits = 2))ms\nSetup Time: $(round.(obj.times.setup_time * 1000, digits = 2))ms\n")
-	obj.times.iter_time != NaN && print("Avg Iter Time: $(round.((obj.times.iter_time / obj.iter) * 1000, digits = 2))ms")
+	!isnan(obj.times.iter_time) && print("Avg Iter Time: $(round.((obj.times.iter_time / obj.iter) * 1000, digits = 2))ms")
 end
 
 struct Info{T <: AbstractFloat}

--- a/test/UnitTests/print.jl
+++ b/test/UnitTests/print.jl
@@ -1,6 +1,6 @@
 using COSMO, Test, Random
 
-settings = COSMO.Settings()
+ws = COSMO.Workspace()
 iter = 10
 cost = 20.
 r_prim = 1.5e-3
@@ -10,8 +10,8 @@ rt = 0.7
 
 
 @testset "Printing" begin
-   @test COSMO.print_iteration(settings, iter, cost, r_prim, r_dual) == nothing
-   @test COSMO.print_iteration(settings, settings.check_termination, cost, r_prim, r_dual) == nothing
+   @test COSMO.print_iteration(ws, iter, cost, r_prim, r_dual) == nothing
+   @test COSMO.print_iteration(ws, ws.settings.check_termination, cost, r_prim, r_dual) == nothing
    @test COSMO.print_result(status, iter, cost, rt) == nothing
 end
 nothing


### PR DESCRIPTION
# Purpose
This is a PR to facilitate the discussion regarding:
- Adding iterative KKT solvers like cg and minres.
- Allowing `P` and `A` to be passed in operator form in `COSMO.jl`.

# ToDo List
- [x] Add cg
- [ ] Add minres
- [ ] Modify COSMO.jl to allow for operators P, A as input.