### PR TITLE
Avoid eigendecomposition in check for positive semidefiniteness

### DIFF
--- a/docs/src/lin_solver.md
+++ b/docs/src/lin_solver.md
@@ -13,9 +13,11 @@ CholmodKKTSolver | Cholmod | Julia's default linear system solver (by SuiteSpars
 PardisoDirectKKTSolver | Pardiso (direct) | Pardiso 6.0 direct solver
 PardisoIndirectKKTSolver | Pardiso (indirect) | Pardiso 6.0 indirect solver
 MKLPardisoKKTSolver | Intel MKL Pardiso | Pardiso optimised for Intel platforms
+IndirectReducedKKTSolver | IterativeSolvers.jl | Conjugate Gradients or MINRES on the reduced KKT linear system.
+IndirectKKTSolver | IterativeSolvers.jl | MINRES on the (full) KKT linear system.
 
 !!! note
-    To use the Pardiso and Intel MKL Pardiso solver, you have to install the respective libraries and the corresponding Julia wrapper. For more information about installing these, visit the [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl) repository page.
+    To use the Pardiso and Intel MKL Pardiso solver, you have to install the respective libraries and the corresponding Julia wrapper. For more information about installing these, visit the [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl) repository page. Likewise in order to use Indirect(Reduced)KKTSolver you have to install [IterativeSolvers.jl](https://github.com/JuliaMath/IterativeSolvers.jl) and [LinearMaps.jl](https://github.com/Jutho/LinearMaps.jl).
 
 COSMO uses the QDLDL linear system solver by default. You can specify a different solver in the settings by using the `kkt_solver` keyword and the respective type:
 
@@ -24,13 +26,19 @@ settings = COSMO.Settings(kkt_solver = CholmodKKTSolver)
 
 ```
 
-COSMO also allows you to pass in solver-specific options. If you want to use Pardiso with verbose printing use the `with_options(solver_type, args...; kwargs...)` syntax:
-
-
+COSMO also allows you to pass in solver-specific options with the `with_options(solver_type, args...; kwargs...)` syntax. For example, if you want to use Pardiso with verbose printing use the following syntax:
 ```julia
 settings = COSMO.Settings(kkt_solver = with_options(PardisoDirectKKTSolver, msg_level_on = true))
-
 ```
+
+Likewise, IndirectReducedKKTSolver and IndirectKKTSolver are also parametrizable with the `with_options(solver_type, args...; kwargs...)` and the accept the following arguments.
+Further options are described as below:
+Keyword Argument | Description
+-------------- |   :-----
+solver_type::Symbol | The iterative solver used for the solution of the linear system. Possible values are :MINRES or :CG for IndirectReducedKKTSolver and :CG for IndirectKKTSolver.
+tol_constant::T and tol_exponent::T | Parameter that defines the solution tolerance for the iterative solvers accross iterations. In particular, the solution tolerance at every iteration is defined as `\text{tol_constant} \text{iteration}^\text{tol_exponent}`
+ | 
+
 
 This also works if you want to use this configuration with JuMP:
 

--- a/docs/src/lin_solver.md
+++ b/docs/src/lin_solver.md
@@ -31,12 +31,11 @@ COSMO also allows you to pass in solver-specific options with the `with_options(
 settings = COSMO.Settings(kkt_solver = with_options(PardisoDirectKKTSolver, msg_level_on = true))
 ```
 
-Likewise, IndirectReducedKKTSolver and IndirectKKTSolver are also parametrizable with the `with_options(solver_type, args...; kwargs...)` and the accept the following arguments.
-Further options are described as below:
+Likewise, IndirectReducedKKTSolver and IndirectKKTSolver are also parametrizable with the `with_options(solver_type, args...; kwargs...)` and accept the following arguments:
 Keyword Argument | Description
 -------------- |   :-----
 solver_type::Symbol | The iterative solver used for the solution of the linear system. Possible values are :MINRES or :CG for IndirectReducedKKTSolver and :CG for IndirectKKTSolver.
-tol_constant::T and tol_exponent::T | Parameter that defines the solution tolerance for the iterative solvers accross iterations. In particular, the solution tolerance at every iteration is defined as `\text{tol_constant} \text{iteration}^\text{tol_exponent}`
+tol_constant::T=T(1.0) and tol_exponent::T=T(1.5) | Parameter that defines the solution tolerance for the iterative solvers accross iterations. In particular, the solution tolerance at every iteration is defined as `\text{tol_constant} \text{iteration}^\text{tol_exponent}`
  | 
 
 

--- a/src/COSMO.jl
+++ b/src/COSMO.jl
@@ -15,6 +15,9 @@ include("./kktsolver.jl")
 if in("Pardiso",keys(Pkg.installed()))
     include("./kktsolver_pardiso.jl")
 end
+if in("IterativeSolvers", keys(Pkg.installed())) && in("LinearMaps", keys(Pkg.installed()))
+    include("./kktsolver_indirect.jl")
+end
 
 include("./algebra.jl")
 include("./projections.jl")

--- a/src/kktsolver_indirect.jl
+++ b/src/kktsolver_indirect.jl
@@ -1,0 +1,170 @@
+using LinearMaps, IterativeSolvers
+
+mutable struct IndirectReducedKKTSolver{TP, TA, T} <: COSMO.AbstractKKTSolver
+    m::Integer
+    n::Integer
+    P::TP
+    A::TA
+    σ::T
+    ρ::Vector{T}
+    tol_constant::T
+    tol_exponent::T
+    # Memory and statistics for cg
+    solver_type::Symbol
+    previous_solution::Vector{T}
+    iteration_counter::Int
+    multiplications::Vector{Int}
+    tmp_n::Vector{T} # n-dimensional used to avoid memory allocation
+    tmp_m::Vector{T} # m-dimensional used to avoid memory allocation
+
+    function IndirectReducedKKTSolver(P::TP, A::TA, σ::T, ρ;
+        solver_type::Symbol=:CG, tol_constant::T=T(1.0), tol_exponent::T=T(1.5)
+        ) where {TP, TA, T}
+        m, n = size(A)
+        if isa(ρ, T)
+            ρ = ρ*ones(T, m)
+        end
+        @assert eltype(P) == eltype(A) == T "Inconsistent element types."
+        @assert solver_type == :CG || solver_type == :MINRES "Solver symbol must be either :CG or :MINRES"
+        new{TP, TA, T}(m, n, P, A, σ, ρ,
+            tol_constant, tol_exponent,
+            solver_type,
+            zeros(T, n), 1, zeros(Int, 0), zeros(T, n), zeros(T, m))
+    end
+end
+
+function solve!(S::IndirectReducedKKTSolver, y::AbstractVector{T}, x::AbstractVector{T}) where {T}
+    # Solves the (KKT) linear system
+    # | P + σI     A'  |  |y1|  =  |x1|
+    # | A        -I/ρ  |  |y2|  =  |x2|
+    # x1,y1: R^n, x2/y2: R^m
+    # where [y1; y2] := y, [x1; x2] := x 
+
+    # In particular we perform cg/minres on the reduced system
+    # (P + σΙ + Α'ρΑ)y1 = x1 + A'ρx2
+    # And then recover y2 as
+    # y2 = ρ(Ay1 - x2)
+
+    x1 = view(x, 1:S.n); y1 = view(y, 1:S.n)
+    x2 = view(x, S.n+1:S.n+S.m); y2 = view(y, S.n+1:S.n+S.m)
+
+    # Form right-hand side for cg/minres: y1 = x1 + A'ρx2
+    @. y2 = S.ρ*x2
+    mul!(y1, S.A', y2)
+    y1 .+= x1
+
+    push!(S.multiplications, 0)
+    function reduced_mul!(y::AbstractVector{T}, x::AbstractVector{T}) where {T}
+        # y = (P + σΙ + Α'ρΑ)x
+        mul!(S.tmp_m, S.A, x)
+        @. S.tmp_m .*= S.ρ
+        mul!(S.tmp_n, S.A', S.tmp_m)
+        axpy!(S.σ, x, S.tmp_n)
+        mul!(y, S.P, x)
+        axpy!(one(T), S.tmp_n, y)
+        S.multiplications[end] += 1
+        return y
+    end
+    L = LinearMap(reduced_mul!, S.n; ismutating=true, issymmetric=true)
+    if S.solver_type == :CG
+        cg!(S.previous_solution, L, y1, tol=get_tolerance(S)/norm(y1))
+    elseif S.solver_type == :MINRES
+        init_residual = norm(L*S.previous_solution - y1)
+        minres!(S.previous_solution, L, y1, tol=get_tolerance(S)/init_residual)
+    end
+    # Sanity check for tolerance
+    # might not always hold for MINRES, as its termination criterion is approximate, (see its documentation)
+    # @assert get_tolerance(S) > norm(L*S.previous_solution - y1)
+    copyto!(y1, S.previous_solution)
+
+    # y2 = Ay1 - x2
+    mul!(y2, S.A, y1)
+    axpy!(-one(T), x2, y2)
+    @. y2 .*= S.ρ
+
+    S.iteration_counter += 1
+
+    return y
+end
+
+mutable struct IndirectKKTSolver{TP, TA, T} <: COSMO.AbstractKKTSolver
+    m::Integer
+    n::Integer
+    P::TP
+    A::TA
+    σ::T
+    ρ::Vector{T}
+    tol_constant::T
+    tol_exponent::T
+    # Memory and statistics for cg
+    solver_type::Symbol
+    previous_solution::Vector{T}
+    iteration_counter::Int
+    multiplications::Vector{Int}
+    tmp_n::Vector{T} # n-dimensional used to avoid memory allocation
+    tmp_m::Vector{T} # m-dimensional used to avoid memory allocation
+
+    function IndirectKKTSolver(P::TP, A::TA, σ::T, ρ; solver_type::Symbol=:MINRES,
+        tol_constant::T=T(1.0), tol_exponent::T=T(1.5)
+        ) where {TP, TA, T}
+        m, n = size(A)
+        if isa(ρ, T)
+            ρ = ρ*ones(T, m)
+        end
+        @assert eltype(P) == eltype(A) == T "Inconsistent element types."
+        @assert solver_type == :MINRES "Solver symbol must be :MINRES"
+        new{TP, TA, T}(m, n, P, A, σ, ρ,
+            tol_constant, tol_exponent,
+            solver_type,
+            zeros(T, m + n), 1, zeros(Int, 0), zeros(T, n), zeros(T, m))
+    end
+end
+
+function solve!(S::IndirectKKTSolver, y::AbstractVector{T}, x::AbstractVector{T}) where {T}
+    # Solves the (KKT) linear system
+    # | P + σI     A'  |  |y1|  =  |x1|
+    # | A        -I/ρ  |  |y2|  =  |x2|
+    # x1,y1: R^n, x2/y2: R^m
+    # where [y1; y2] := y, [x1; x2] := x 
+    push!(S.multiplications, 0)
+    function kkt_mul!(y::AbstractVector{T}, x::AbstractVector{T}) where {T}
+        # Performs
+        # |y1| = | P + σI     A'  |  |x1|
+        # |y2| = | A        -I/ρ  |  |x2|
+        x1 = view(x, 1:S.n); y1 = view(y, 1:S.n)
+        x2 = view(x, S.n+1:S.n+S.m); y2 = view(y, S.n+1:S.n+S.m)
+
+        mul!(S.tmp_n, S.A', x2)
+        axpy!(S.σ, x1, S.tmp_n)
+        mul!(y1, S.P, x1)
+        axpy!(one(T), S.tmp_n, y1)
+
+        @. y2 = -x2/S.ρ
+        mul!(S.tmp_m, S.A, x1)
+        axpy!(one(T), S.tmp_m, y2)
+
+        S.multiplications[end] += 1
+        return y
+    end
+    L = LinearMap(kkt_mul!, S.n + S.m; ismutating=true, issymmetric=true)
+    if S.solver_type == :MINRES
+        init_residual = norm(L*S.previous_solution - y)
+        minres!(S.previous_solution, L, y, tol=get_tolerance(S)/init_residual)
+    end
+    # Sanity check for tolerance
+    # might not always hold for MINRES, as its termination criterion is approximate, (see its documentation)
+    # @assert get_tolerance(S) > norm(L*S.previous_solution - y)
+    copyto!(y, S.previous_solution)
+
+    S.iteration_counter += 1
+
+    return y
+end
+
+function update_rho!(S::Union{IndirectReducedKKTSolver, IndirectKKTSolver}, ρ)
+    S.ρ .= ρ
+end
+
+function get_tolerance(S::Union{IndirectReducedKKTSolver, IndirectKKTSolver})
+    return S.tol_constant/S.iteration_counter^S.tol_exponent
+end

--- a/test/UnitTests/kktsolver.jl
+++ b/test/UnitTests/kktsolver.jl
@@ -1,5 +1,9 @@
 using COSMO, Test, LinearAlgebra, SparseArrays, Random, QDLDL, Pkg
-rng = Random.MersenneTwister(2401)
+include("COSMOTestUtils.jl")
+
+rng = Random.MersenneTwister(1)
+
+T = Float64
 
 function make_test_kkt(P, A, sigma, rho)
 
@@ -11,39 +15,99 @@ function make_test_kkt(P, A, sigma, rho)
     return K
 end
 
-solver_types = [COSMO.QdldlKKTSolver
-                COSMO.CholmodKKTSolver]
+function add_kwargs(array; kwargs...)
+    push!(array, kwargs)
+end
+
+solver_types = []
+solver_tols = []
+params = []
+push!(solver_types, COSMO.QdldlKKTSolver)
+push!(solver_tols, 1e-10)
+add_kwargs(params)
+push!(solver_types, COSMO.CholmodKKTSolver)
+push!(solver_tols, 1e-10)
+add_kwargs(params)
+# solver_types = [COSMO.QdldlKKTSolver
+                # COSMO.CholmodKKTSolver]
 
 # optional dependencies
 if in("Pardiso",keys(Pkg.installed()))
     using Pardiso
-    Pardiso.MKL_PARDISO_LOADED[] && push!(solver_types, COSMO.MKLPardisoKKTSolver)
-    Pardiso.PARDISO_LOADED[]     && push!(solver_types, COSMO.PardisoDirectKKTSolver)
-    Pardiso.PARDISO_LOADED[]     && push!(solver_types, COSMO.PardisoIndirectKKTSolver)
+    if Pardiso.MKL_PARDISO_LOADED[] 
+        push!(solver_types, COSMO.MKLPardisoKKTSolver)
+        push!(solver_tols, 1e-10)
+            add_kwargs(params)
+        end
+    if Pardiso.PARDISO_LOADED[] 
+        push!(solver_types, COSMO.PardisoDirectKKTSolver)
+        push!(solver_tols, 1e-10)
+        add_kwargs(params)
+    end
+    if Pardiso.PARDISO_LOADED[]
+        push!(solver_types, COSMO.PardisoIndirectKKTSolver)
+        push!(solver_tols, 5e-5)
+        add_kwargs(params)
+    end
 end
 
-solver_tols   = [1e-10, 1e-10, 1e-10, 1e-10, 5e-5]
+if in("IterativeSolvers",keys(Pkg.installed()))
+    using IterativeSolvers
+    push!(solver_types, COSMO.IndirectReducedKKTSolver)
+    push!(solver_tols, 1e-3)
+    add_kwargs(params, solver_type=:CG)
 
- @testset "$(solver_types[i]) : KKT solver tests" for i = 1:length(solver_types)
+    push!(solver_types, COSMO.IndirectReducedKKTSolver)
+    push!(solver_tols, 1e-3)
+    add_kwargs(params, solver_type=:MINRES)
+
+    push!(solver_types, COSMO.IndirectKKTSolver)
+    push!(solver_tols, 1e-3)
+    add_kwargs(params, solver_type=:MINRES)
+end
+
+
+ @testset "$(solver_types[i]) $(params[i]) : KKT solver tests" for i = 1:length(solver_types)
 
     m = 10
     n = 20
 
-    for rho1 in [rand(1), rand(1)[], rand(m)],
-        rho2 in [rand(1), rand(m)],
-        sigma in [rand(1), rand(1)[], rand(n)]
+    for rho1 in [rand(T), rand(T, m)],
+        rho2 in [rand(T), rand(T, m)],
+        sigma in [rand(T)]
 
         P  = sparse(generate_pos_def_matrix(n, rng))
         A  = sprandn(m, n, 0.2)
         b = randn(m + n)
 
-        F = solver_types[i](P, A, sigma, rho1)
+        F = solver_types[i](P, A, sigma, rho1; params[i]...)
+        if isa(F, COSMO.IndirectReducedKKTSolver) || isa(F, COSMO.IndirectKKTSolver)
+            # Technically, we should have been able to set the tolerance even lower
+            # But, currently, issues in IterativeSolvers.jl do not allow this
+            # See: https://github.com/JuliaMath/IterativeSolvers.jl/pull/244
+            F.iteration_counter = 10^4 # This forces CG's/MINRES tolerance to be 1/10^4
+        end
         J = make_test_kkt(P, A, sigma, rho1)
         x = copy(b)
 
         #test a single solve
         COSMO.solve!(F, x, b)
         @test norm(x - J \ b) <= solver_tols[i]
+
+        # Check that warm starting works
+        # Invoking again an indirect solver should result in the solution with only
+        # one matrix vector multiplication
+        if isa(F, COSMO.IndirectReducedKKTSolver) || isa(F, COSMO.IndirectKKTSolver)
+            # The calculation of the residual, and thus the termination criterion, of
+            # MINRES is approximate. Thus warm started solutions won't necessarily finish in one step
+            # For this reason we don't check warm starting with MINRES for now :(
+            if F.solver_type != :MINRES
+                COSMO.solve!(F, x, b)
+                @show F.multiplications
+                @test F.multiplications[end] <= 1 
+                @test norm(x - J \ b) <= solver_tols[i]
+            end
+        end
 
         #test a rho update and solve
         J = make_test_kkt(P, A, sigma, rho2)


### PR DESCRIPTION
Uses pivoted Cholesky instead of eigendecomposition for checking positive/negative semidefiniteness. Advantages of the approach include that Cholesky is faster than eigen-decomposition, scales much better with parallelism and can exploit sparsity.

The positive semidefiniteness checks can be become computationally relevant when using approximate projections, as, in this case, we are trying to avoid big eigendecompositions as much as possible.

References [[1]](https://math.stackexchange.com/a/13311) [[2]](https://math.stackexchange.com/questions/13282/determining-whether-a-symmetric-matrix-is-positive-definite-algorithm#comment34777_15682 
) [[3]](https://math.stackexchange.com/questions/13282/determining-whether-a-symmetric-matrix-is-positive-definite-algorithm#comment34777_15682) [[4]](https://software.intel.com/en-us/mkl-developer-reference-c-pstrf)
