### PR TITLE
Avoid eigendecomposition in check for positive semidefiniteness

### DIFF
--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -111,6 +111,16 @@ end
 
 lmul!(L::IdentityMatrix, M::AbstractMatrix) = L.λ ? M : M .= zero(eltype(M))
 
+function lmul!(L::Diagonal, x::AbstractVector)
+	(length(L.diag) == length(x)) || throw(DimensionMismatch())
+	@. x = x * L.diag
+	return nothing
+end
+
+lmul!(L::IdentityMatrix, x::AbstractVector) = L.λ ? x : x .= zero(eltype(x))
+
+
+
 function rmul!(M::SparseMatrixCSC, R::Diagonal)
 
 	m, n = size(M)

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -201,10 +201,9 @@ function is_pos_def!(X::AbstractMatrix{T}, tol::T=zero(T)) where T
 	return issuccess(F)
 end
 
-function is_pos_def!(X::SparseMatrixCSC{T}, tol::T=zero(T)) where T
-	# For sparse matrices pivoting in cholesky is on by default
-	F = cholesky!(Symmetric(X), shift = tol, check = false)
-	return issuccess(F)
+function is_neg_def!(X::AbstractMatrix{T}, tol::T=zero(T)) where T
+	@. X *= -one(T)
+	return is_pos_def!(X, tol)
 end
 
 is_pos_def(X::AbstractMatrix{T}, tol::T=zero(T)) where T = is_pos_def!(copy(X), tol)

--- a/src/convexset.jl
+++ b/src/convexset.jl
@@ -272,13 +272,13 @@ end
 function in_dual(x::AbstractVector{T}, cone::Union{PsdCone{T}, DensePsdCone{T}}, tol::T) where{T}
 	n = cone.sqrt_dim
 	X = reshape(x, n, n)
-  return is_pos_sem_def(X, tol)
+  return is_pos_def(X, tol)
 end
 
 function in_pol_recc(x::AbstractVector{T}, cone::Union{PsdCone{T}, DensePsdCone{T}}, tol::T) where{T}
 	n = cone.sqrt_dim
 	X = reshape(x, n, n)
-	return is_neg_sem_def(X, tol)
+	return is_neg_def(X, tol)
 end
 
 
@@ -349,14 +349,14 @@ end
 function in_dual(x::AbstractVector{T}, cone::Union{PsdConeTriangle{T}, DensePsdConeTriangle{T}}, tol::T) where{T}
     n = cone.sqrt_dim
     populate_upper_triangle!(cone.X, x, 1 / sqrt(2))
-    return is_pos_sem_def(cone.X, tol)
+    return is_pos_def(cone.X, tol)
 end
 
 function in_pol_recc(x::AbstractVector{T}, cone::Union{PsdConeTriangle{T}, DensePsdConeTriangle{T}}, tol::T) where{T}
     n = cone.sqrt_dim
     populate_upper_triangle!(cone.X, x, 1 / sqrt(2))
     Xs = Symmetric(cone.X)
-    return is_neg_sem_def(cone.X, tol)
+    return is_neg_def(cone.X, tol)
 end
 
 function allocate_memory!(cone::Union{PsdConeTriangle{T}, DensePsdConeTriangle{T}}) where {T}

--- a/test/UnitTests/algebra.jl
+++ b/test/UnitTests/algebra.jl
@@ -61,6 +61,11 @@ rng = Random.MersenneTwister(9191)
   COSMO.lmul!(I, M)
   @test M == Mo
 
+  x = rand(5)
+  y = copy(x)
+  COSMO.lmul!(L, x)
+  @test norm(x - L * y, Inf ) <= 1e-10
+
   # rmul!()
   R = Diagonal(rand(rng, 5))
   Mo = sprand(rng, 5, 5, 0.8)

--- a/test/UnitTests/algebra.jl
+++ b/test/UnitTests/algebra.jl
@@ -95,14 +95,14 @@ rng = Random.MersenneTwister(9191)
   @test Symmetric(A) == (0.5 * (B + B'))
   @test_throws AssertionError COSMO.symmetrize_upper!(rand(2, 3));
 
-  # is_pos_sem_def()
+  # is_pos_def()
   A = Symmetric(randn(rng, 4, 4))
   Apos = A + 4 * Matrix(1.0I, 4, 4)
   Aneg = A - 4 * Matrix(1.0I, 4, 4)
-  @test COSMO.is_pos_sem_def(Apos, 1e-6)
-  @test !COSMO.is_pos_sem_def(Aneg, 1e-6)
-  @test COSMO.is_neg_sem_def(Aneg, 1e-6)
-  @test !COSMO.is_neg_sem_def(Apos, 1e-6)
+  @test COSMO.is_pos_def(Apos, 1e-6)
+  @test !COSMO.is_pos_def(Aneg, 1e-6)
+  @test COSMO.is_neg_def(Aneg, 1e-6)
+  @test !COSMO.is_neg_def(Apos, 1e-6)
 
 end
 nothing


### PR DESCRIPTION
Uses ~~pivoted~~ Cholesky instead of eigendecomposition for checking positive/negative semidefiniteness. Advantages of the approach include that Cholesky is faster than eigen-decomposition, scales much better with parallelism and can exploit sparsity.

The positive semidefiniteness checks can be become computationally relevant when using approximate projections, as, in this case, we are trying to avoid big eigendecompositions as much as possible.

References [[1]](https://math.stackexchange.com/a/13311) ~~[[2]](https://math.stackexchange.com/questions/13282/determining-whether-a-symmetric-matrix-is-positive-definite-algorithm#comment34777_15682 
)  [[3]](https://software.intel.com/en-us/mkl-developer-reference-c-pstrf)~~
