### PR TITLE
Pg/depend check fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,11 +11,22 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QDLDL = "bfc457fd-c171-5ab7-bd9e-d5dbfc242d63"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+
+[compat]
+DataStructures = "~0.17.0"
+IterativeSolvers = "~0.8.1"
+LinearMaps = "~2.5.1"
+MathOptInterface = "~0.9.7"
+QDLDL = "~0.1.3"
+UnsafeArrays = "^0.3"
+julia = "^1"
+Requires = "~1.0.1"
 
 [extras]
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
@@ -23,13 +34,3 @@ LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 
 [targets]
 test = ["IterativeSolvers", "LinearMaps"]
-
-
-[compat]
-QDLDL = "~0.1.3"
-DataStructures = "~0.17.0"
-MathOptInterface = "~0.9.7"
-UnsafeArrays = "^0.3"
-julia = "^1"
-LinearMaps = "~2.5.1"
-IterativeSolvers = "~0.8.1"

--- a/src/COSMO.jl
+++ b/src/COSMO.jl
@@ -1,42 +1,42 @@
 __precompile__()
 module COSMO
 
-using SparseArrays, LinearAlgebra, SuiteSparse, QDLDL, Pkg, DataStructures
+    using SparseArrays, LinearAlgebra, SuiteSparse, QDLDL, Pkg, DataStructures, Requires
 
 
-export assemble!, warmStart!, empty_model!
+    export assemble!, warmStart!, empty_model!
 
-const DefaultFloat = Float64
-const DefaultInt   = LinearAlgebra.BlasInt
+    const DefaultFloat = Float64
+    const DefaultInt   = LinearAlgebra.BlasInt
 
 
-include("./kktsolver.jl")
-# optional dependencies
-if in("Pardiso",keys(Pkg.installed()))
-    include("./kktsolver_pardiso.jl")
-end
-if in("IterativeSolvers", keys(Pkg.installed())) && in("LinearMaps", keys(Pkg.installed()))
-    include("./kktsolver_indirect.jl")
-end
+    include("./kktsolver.jl")
 
-include("./algebra.jl")
-include("./projections.jl")
-include("./trees.jl")
-include("./clique_merging.jl")
-include("./settings.jl")
-include("./types.jl")
-include("./constraint.jl")
-include("./parameters.jl")
-include("./residuals.jl")
-include("./scaling.jl")
-include("./infeasibility.jl")
-include("./transformations.jl")
-include("./chordal_decomposition.jl")
-include("./printing.jl")
-include("./setup.jl")
-include("./solver.jl")
-include("./interface.jl")           
-include("./MOIWrapper.jl")
+    # optional dependencies
+    @require Pardiso="46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2" include("./kktsolver_pardiso.jl")
+
+    @require IterativeSolvers="42fd0dbc-a981-5370-80f2-aaf504508153" begin
+        @require LinearMaps="7a12625a-238d-50fd-b39a-03d52299707e" include("./kktsolver_indirect.jl")
+    end
+
+    include("./algebra.jl")
+    include("./projections.jl")
+    include("./trees.jl")
+    include("./clique_merging.jl")
+    include("./settings.jl")
+    include("./types.jl")
+    include("./constraint.jl")
+    include("./parameters.jl")
+    include("./residuals.jl")
+    include("./scaling.jl")
+    include("./infeasibility.jl")
+    include("./transformations.jl")
+    include("./chordal_decomposition.jl")
+    include("./printing.jl")
+    include("./setup.jl")
+    include("./solver.jl")
+    include("./interface.jl")
+    include("./MOIWrapper.jl")
 
 
 end #end module

--- a/src/kktsolver_indirect.jl
+++ b/src/kktsolver_indirect.jl
@@ -1,6 +1,6 @@
 using LinearMaps, IterativeSolvers
 
-mutable struct IndirectReducedKKTSolver{TP, TA, T} <: COSMO.AbstractKKTSolver
+mutable struct IndirectReducedKKTSolver{TP, TA, T} <: AbstractKKTSolver
     m::Integer
     n::Integer
     P::TP
@@ -38,7 +38,7 @@ function solve!(S::IndirectReducedKKTSolver, y::AbstractVector{T}, x::AbstractVe
     # | P + σI     A'  |  |y1|  =  |x1|
     # | A        -I/ρ  |  |y2|  =  |x2|
     # x1,y1: R^n, x2/y2: R^m
-    # where [y1; y2] := y, [x1; x2] := x 
+    # where [y1; y2] := y, [x1; x2] := x
 
     # In particular we perform cg/minres on the reduced system
     # (P + σΙ + Α'ρΑ)y1 = x1 + A'ρx2
@@ -87,7 +87,7 @@ function solve!(S::IndirectReducedKKTSolver, y::AbstractVector{T}, x::AbstractVe
     return y
 end
 
-mutable struct IndirectKKTSolver{TP, TA, T} <: COSMO.AbstractKKTSolver
+mutable struct IndirectKKTSolver{TP, TA, T} <: AbstractKKTSolver
     m::Integer
     n::Integer
     P::TP
@@ -125,7 +125,7 @@ function solve!(S::IndirectKKTSolver, y::AbstractVector{T}, x::AbstractVector{T}
     # | P + σI     A'  |  |y1|  =  |x1|
     # | A        -I/ρ  |  |y2|  =  |x2|
     # x1,y1: R^n, x2/y2: R^m
-    # where [y1; y2] := y, [x1; x2] := x 
+    # where [y1; y2] := y, [x1; x2] := x
     push!(S.multiplications, 0)
     function kkt_mul!(y::AbstractVector{T}, x::AbstractVector{T}) where {T}
         # Performs
@@ -148,8 +148,8 @@ function solve!(S::IndirectKKTSolver, y::AbstractVector{T}, x::AbstractVector{T}
     end
     L = LinearMap(kkt_mul!, S.n + S.m; ismutating=true, issymmetric=true)
     if S.solver_type == :MINRES
-        init_residual = norm(L*S.previous_solution - y)
-        minres!(S.previous_solution, L, y, tol=get_tolerance(S)/init_residual)
+        init_residual = norm(L*S.previous_solution - x)
+        minres!(S.previous_solution, L, x, tol=get_tolerance(S)/init_residual)
     end
     # Sanity check for tolerance
     # might not always hold for MINRES, as its termination criterion is approximate, (see its documentation)
@@ -170,4 +170,4 @@ function get_tolerance(S::Union{IndirectReducedKKTSolver, IndirectKKTSolver})
 end
 
 CGIndirectKKTSolver(args...; kwargs...) = IndirectReducedKKTSolver(args...; solver_type = :CG, kwargs...)
-MINRESIndirectKKTSolver(args...; kwargs...) = IndirecKKTSolver(args...; solver_type = :MINRES, kwargs...)
+MINRESIndirectKKTSolver(args...; kwargs...) = IndirectKKTSolver(args...; solver_type = :MINRES, kwargs...)

--- a/src/kktsolver_pardiso.jl
+++ b/src/kktsolver_pardiso.jl
@@ -106,6 +106,15 @@ function _pardiso_common_init(P, A, sigma, rho, Solver::Type, iparm::Dict{Int64,
     # set to allow non-default iparams
     set_iparm!(ps, 1, 1)
 
+    # use some standard configuration settings
+    # as our internal defaults.  Can be overridden
+    # by user options in the iparm dict to follow.
+    # These are the same as the OSQP Pardiso defaults
+    
+    set_iparm!(ps, 2, 3)    #Parallel METIS reordering
+    set_iparm!(ps, 8, 0)    #Number of iterative refinement steps (auto, performs them only if perturbed pivots are obtained)
+    set_iparm!(ps, 10, 13)  #Perturb the pivot elements with 1E-13
+
     # set user specific parameters
     for (i, v) in iparm
         set_iparm!(ps, i, v)

--- a/test/UnitTests/options_factory.jl
+++ b/test/UnitTests/options_factory.jl
@@ -12,13 +12,13 @@ iparms = Dict{Int64, Int64}()
 iparms[13] = 100
 num_threads = 2
 
-settings = COSMO.Settings(kkt_solver = with_options(COSMO.MKLPardisoKKTSolver, iparm = iparms, num_threads = num_threads, msg_level_on = false))
+settings = COSMO.Settings(kkt_solver = with_options(MKLPardisoKKTSolver, iparm = iparms, num_threads = num_threads, msg_level_on = false))
 model = COSMO.Model()
 assemble!(model, P, q, c1, settings = settings)
 model.ρvec = settings.rho * ones(size(model.p.A, 1))
 COSMO._make_kkt_solver!(model)
 
-  @test typeof(model.kkt_solver) <: COSMO.MKLPardisoKKTSolver
+  @test typeof(model.kkt_solver) <: MKLPardisoKKTSolver
   # @test Pardiso.get_nprocs(model.kkt_solver.ps) == num_threads
   @test Pardiso.get_iparm(model.kkt_solver.ps, 13) == iparms[13]
 
@@ -42,5 +42,3 @@ COSMO._make_kkt_solver!(model)
 
 
 end
-
-

--- a/test/run_cosmo_tests.jl
+++ b/test/run_cosmo_tests.jl
@@ -1,4 +1,4 @@
-using COSMO, Random, Test, Pkg
+using COSMO, Random, Test, Pkg, Requires
 rng = Random.MersenneTwister(12345)
 
 include("./UnitTests/COSMOTestUtils.jl")
@@ -26,8 +26,7 @@ include("./UnitTests/COSMOTestUtils.jl")
   include("./UnitTests/clique_merging_example.jl")
 
     # optional unittests
-  if in("Pardiso",keys(Pkg.installed()))
-    include("./UnitTests/options_factory.jl")
-  end
+  @require Pardiso="46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2" include("./UnitTests/options_factory.jl")
 
 end
+exit


### PR DESCRIPTION
- Fixes problems with slow matrix reordering on pardiso by changing default settings.

- Changes to `Requires` package to check for optional dependencies for linear solver packages (Pardiso etc).