### PR TITLE
Bump DataStructures.jl to support v0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 AMD = "^0.4.0"
-DataStructures = "^0.17.0"
+DataStructures = "^0.17.0, ^0.18.0"
 IterTools = "^1"
 MathOptInterface = "~0.9.16"
 QDLDL = "~0.1.4"


### PR DESCRIPTION
This is a proposed bump to allow COSMO to use the most recent versions of DataStructures.jl. I ran the test suite, and all tests passed when using DataStructures.jl v0.18.8, but I am not sure if there may be parts of the code using this package that aren't tested as thoroughly.

Fixes #118 