### PR TITLE
Fix constraints warm-up.

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -595,7 +595,7 @@ function pass_attributes!(dest::Optimizer{T}, src::MOI.ModelLike, idxmap::MOIU.I
             elseif attr == MOI.ConstraintPrimalStart() || attr == MOI.ConstraintDualStart()
                 for ci in cis_src
                     value = MOI.get(src, attr, ci)
-                    process_warm_start!(dest, attr, ci, value)
+                    process_warm_start!(dest, attr, idxmap[ci], value)
                 end
             else
                 throw(MOI.UnsupportedAttribute(attr))


### PR DESCRIPTION
L598 pass `ci` into `process_warm_start`, but `constraint_rows` expects a `ci_dest`.

https://github.com/oxfordcontrol/COSMO.jl/blob/8689f7611d0e8508b5e75d00b27cf33a39c32a1b/src/MOI_wrapper.jl#L197-L199

This PR just adds the missing index transform.

(I‘m not familiar with MOI interface. So it's hard for me to add a test for this.)