### PR TITLE
fix: merge_strategy() is an instance, not a type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "COSMO"
 uuid = "1e616198-aa4e-51ec-90a2-23f7fbd31d8d"
 authors = ["Michael <michael@garstka.org>"]
-version = "0.8.6"
+version = "0.8.7"
 
 [deps]
 AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"

--- a/src/accelerator_interface.jl
+++ b/src/accelerator_interface.jl
@@ -35,7 +35,7 @@ end
 check_activation!(ws::Workspace, activation_reason::AccuracyActivation, num_iter::Int64) = nothing
 
 
-function check_activation!(ws::Workspace, activation_reason::AccuracyActivation, r::ResultInfo) where {T <: AbstractFloat}
+function check_activation!(ws::Workspace, activation_reason::AccuracyActivation, r::ResultInfo)
     if !ws.accelerator_active
         tol = activation_reason.start_accuracy
         
@@ -45,7 +45,7 @@ function check_activation!(ws::Workspace, activation_reason::AccuracyActivation,
     end
 end
 
-check_activation!(ws::Workspace, activation_reason::Union{IterActivation, ImmediateActivation}, r::ResultInfo) where {T <: AbstractFloat}= nothing
+check_activation!(ws::Workspace, activation_reason::Union{IterActivation, ImmediateActivation}, r::ResultInfo) = nothing
 
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -197,7 +197,7 @@ mutable struct SparsityPattern
     # clique merging only if more than one clique present
     if sntree.num > 1
 		merge_cliques!(sntree)
-	elseif merge_strategy <: AbstractGraphBasedMerge
+	elseif merge_strategy isa AbstractGraphBasedMerge
 		# if no merging attempt happens for a clique graph, we still have to convert the snd and sep back to Array{Array{Int}, 1}
 		# for consistency
 		sntree.snd = sort.(collect.(sntree.snd))


### PR DESCRIPTION
This is the error I got:
```julia
ERROR: LoadError: TypeError: in <:, expected Type, got a value of type COSMO.CliqueGraphMerge
Stacktrace:
  [1] COSMO.SparsityPattern(L::SparseArrays.SparseMatrixCSC{Float64, Int64}, N::Int64, ordering::Vector{Int64}, merge_strategy::COSMO.OptionsFactory{COSMO.CliqueGraphMerge}, row_range::UnitRange{Int64}, cone_ind::Int64, nz_ind_map::SparseArrays.SparseVector{Int64, Int64})
    @ COSMO ~/.julia/packages/COSMO/74ztU/src/types.jl:200
  [2] _analyse_sparsity_pattern(ci::COSMO.ChordalInfo{Float64}, csp::Vector{Int64}, sets::Vector{COSMO.AbstractConvexSet}, C::COSMO.PsdConeTriangle{Float64}, k::Int64, psd_row_range::UnitRange{Int64}, sp_ind::Int64, merge_strategy::COSMO.OptionsFactory{COSMO.CliqueGraphMerge})
    @ COSMO ~/.julia/packages/COSMO/74ztU/src/chordal_decomposition/chordal_decomposition.jl:64
  [3] analyse_sparsity_pattern!(ci::COSMO.ChordalInfo{Float64}, csp::Vector{Int64}, sets::Vector{COSMO.AbstractConvexSet}, C::COSMO.PsdConeTriangle{Float64}, k::Int64, psd_row_range::UnitRange{Int64}, sp_ind::Int64, merge_strategy::COSMO.OptionsFactory{COSMO.CliqueGraphMerge})
    @ COSMO ~/.julia/packages/COSMO/74ztU/src/chordal_decomposition/chordal_decomposition.jl:55
  [4] find_sparsity_patterns!(ws::COSMO.Workspace{Float64})
    @ COSMO ~/.julia/packages/COSMO/74ztU/src/chordal_decomposition/chordal_decomposition.jl:47
  [5] chordal_decomposition!(ws::COSMO.Workspace{Float64})
    @ COSMO ~/.julia/packages/COSMO/74ztU/src/chordal_decomposition/chordal_decomposition.jl:18
  [6] macro expansion
    @ ./timing.jl:382 [inlined]
  [7] optimize!(ws::COSMO.Workspace{Float64})
    @ COSMO ~/.julia/packages/COSMO/74ztU/src/solver.jl:90
  [8] optimize!
    @ ~/.julia/packages/COSMO/74ztU/src/MOI_wrapper.jl:151 [inlined]
[...]
```
With the fix it's gone and things work as usual ;)

CC: @thinh-le